### PR TITLE
Height Bug of the Frame Component is Fixed

### DIFF
--- a/frontend/src/components/Frame/index.jsx
+++ b/frontend/src/components/Frame/index.jsx
@@ -12,7 +12,7 @@ const Frame = ({ children }) => {
     <Content>
       <MainHeader />
       <ProfileSider/>
-      <Row style={{ height: "100vh"}} align="top" justify="start">
+      <Row align="top" justify="start">
         {children}
       </Row>
     </Content>

--- a/frontend/src/components/Frame/style.js
+++ b/frontend/src/components/Frame/style.js
@@ -2,7 +2,6 @@ import styled from "styled-components";
 import { Layout } from "antd";
 
 export const Content = styled(Layout)`
-  height: 100vh;
   background: white;
-  margin-top: 64px;
+  padding-top: 64px;
   `;


### PR DESCRIPTION
**Intro:**
There was a height bug at the frame component at the frame component.

**Bug description:**
When you open the page, scroller appears at the left side even if there are not much content to scroll the page.

**How is it fixed:**
While managing the spacing in the component margin is used instead of padding.

**Other changes:**
Some unnecessary stylings are removed.