### PR TITLE
Fix status bug on project details

### DIFF
--- a/frontend/src/pages/ProjectDetails/index.jsx
+++ b/frontend/src/pages/ProjectDetails/index.jsx
@@ -81,7 +81,7 @@ const ProjectDetails = () => {
     return [user, ...collabs]
   }
 
-  const statusMap = ["cancelled", "completed", "in progress", "team building", "hibernating"]
+  const statusMap = ["Cancelled", "Completed", "In Progress", "Hibernating", "Team Building"]
   const statusColorMap = ["red", "green", "cyan", "purple", "volcano"]
 
   const deadlineColor = (deadline_str) => {


### PR DESCRIPTION
I simply changed the order of tags on project details page to match project edit and mobile's implementations.