### PR TITLE
Frontend Event Details

### DIFF
--- a/frontend/src/pages/EventDetails/components/UserResult/index.jsx
+++ b/frontend/src/pages/EventDetails/components/UserResult/index.jsx
@@ -1,0 +1,37 @@
+import React from "react";
+
+import { Col, Avatar, Button, Row } from "antd";
+import {
+  Layout,
+  Title,
+  Summary,
+} from "./style";
+
+const userResult = ({ id, img, name, department, university, profileLink, selected, buttonClicked }) => {
+
+  return (  
+    <Layout key={id} wrap={false} xs={18} sm={18} md={18} lg={18} >
+    <Col flex="40px">
+      <Avatar size={32}  src={img} style={{boxShadow: "0px 4px 4px rgba(0,0,0,0.25)", margin: "10px"}} />
+    </Col>
+    <Col flex="auto" justify="center">
+      <Row wrap={false}>
+          <Title>
+            {name}
+          </Title>
+      </Row>
+      <Row>
+        <Summary>
+          {university} {department}
+        </Summary>
+      </Row>
+    </Col>
+    <Button type="text" onClick={buttonClicked} style={{margin: "auto"}}>
+      {selected ? "Remove" : "Add"}
+    </Button>
+  </Layout>
+  );
+};
+
+export default userResult;
+

--- a/frontend/src/pages/EventDetails/components/UserResult/style.js
+++ b/frontend/src/pages/EventDetails/components/UserResult/style.js
@@ -1,0 +1,82 @@
+import styled from "styled-components";
+import { Row } from "antd";
+
+export const Layout = styled(Row)`
+  border-bottom: 1px solid rgba(0,0,0,0.15);
+  padding-top: 1.2em;
+`;
+
+export const Title = styled.p`
+  margin: 0;
+  padding-left: 1em;
+  font-weight: 500;
+
+  @media only screen and (max-width: 768px) {
+    font-size: 14px;
+  }
+
+  @media only screen and (min-width: 768px) {
+    font-size: 16px;
+  }
+`;
+
+export const Info = styled.p`
+margin: 0;
+padding-left: 1em;
+color: #8E8585;
+font-weight: 300;
+font-size: 14px;
+
+@media only screen and (max-width: 768px) {
+  font-size: 12px;
+}
+
+@media only screen and (min-width: 768px) {
+  font-size: 14px;
+}
+`;
+
+export const Summary = styled.p`
+  margin: 0;
+  padding-left: 1em;
+  font-weight: 300;
+
+  @media only screen and (max-width: 768px) {
+    font-size: 12px;
+  }
+  
+  @media only screen and (min-width: 768px) {
+    font-size: 14px;
+  }
+`;
+
+export const Footer = styled.p`
+  margin: 0;
+  color: #8E8585;
+  font-weight: 300;
+  text-align: right;
+
+  @media only screen and (max-width: 768px) {
+    font-size: 12px;
+  }
+  
+  @media only screen and (min-width: 768px) {
+    font-size: 14px;
+  }
+`;
+
+export const TopNote = styled.p`
+  margin: 0;
+  color: #8E8585;
+  font-weight: 300;
+  text-align: right;
+
+  @media only screen and (max-width: 768px) {
+    font-size: 12px;
+  }
+  
+  @media only screen and (min-width: 768px) {
+    font-size: 14px;
+  }
+`;
+

--- a/frontend/src/pages/EventDetails/index.jsx
+++ b/frontend/src/pages/EventDetails/index.jsx
@@ -48,7 +48,7 @@ const EventDetails = () => {
       setEventData(response.data.result)
       setLoadingProject(false)
     }).catch((error) => {
-      //history.goBack()
+      history.goBack()
     })
   }, [eventId, history]);
 

--- a/frontend/src/pages/EventDetails/index.jsx
+++ b/frontend/src/pages/EventDetails/index.jsx
@@ -31,22 +31,9 @@ function NewlineText(text) {
 
 
 const EventDetails = () => {
-
-  const DummyEventData = {
-    id: 62,
-    type: 'Rave Party',
-    event_tags: ['Ankara', 'Birds of Mind'],
-    isPublic: true,
-    title: 'MONGO B-Party',
-    body: 'Come join us at Rave Istanbul to enjoy this unique and action-packed party that will have you on your feet all night long! Be prepared for unexpected surprise acts, packed events, and a wild adventure that will have you dancing and jumping until the end of the night!\n\nFriday, June 6th:\n10:00 PM: WELCOME\n10:30 PM: Rave Party\nMidnight: Foam Shower\n\nOrganized by Kusadasi Spring Festival',
-    link: 'https://www.raveparty.com/',
-    location: 'Osmanbey / ISTANBUL',
-    date: '06/06/2021',
-    other: 'Strimg',
-  }
 	 
   const [loadingProject, setLoadingProject] = useState(true);
-  const [eventData, setEventData] = useState(DummyEventData);
+  const [eventData, setEventData] = useState({});
 
   const { eventId } = useParams()
   const history = useHistory()

--- a/frontend/src/pages/EventDetails/index.jsx
+++ b/frontend/src/pages/EventDetails/index.jsx
@@ -116,7 +116,7 @@ const EventDetails = () => {
                   twoToneColor={deadlineColor(eventData.date)}
                   style={{ fontSize: "12px", marginRight: "8px" }}
                 />
-                {moment(eventData.date).format("DD/MM/YYYY")} &nbsp;
+                {moment(eventData.date).format("DD/MM/YYYY HH:mm")} &nbsp;
               </span>
             ) : (
               <></>

--- a/frontend/src/pages/EventDetails/index.jsx
+++ b/frontend/src/pages/EventDetails/index.jsx
@@ -1,0 +1,490 @@
+import React, { useEffect, useState } from "react";
+import { useHistory, useParams } from "react-router-dom";
+import { useDispatch } from "react-redux";
+import api from "../../axios";
+import moment from "moment";
+
+import { Row, Col, Tag, Avatar, Spin, Button, Input } from "antd";
+import {
+  UnlockFilled,
+  FileOutlined,
+  ClockCircleTwoTone,
+  EditFilled,
+  UsergroupAddOutlined,
+  LockFilled,
+} from "@ant-design/icons";
+import { sendJoinRequest, sendBatchInviteRequest } from "../../redux/collaboration/api";
+import Frame from "../../components/Frame";
+import PrimaryButton from "../../components/PrimaryButton";
+import {
+  H1,
+  H3,
+  H4,
+  Main,
+  DateSection,
+  Tags,
+  Summary,
+  Deadlines,
+  Files,
+  FileContainer,
+  FileDiv,
+  Side,
+  UserDiv,
+  FadedText,
+  UserModal,
+  FadedDark,
+  IndentedBlock,
+} from "./style";
+import theme from "../../theme";
+import UserResult from "./components/UserResult";
+
+const EventDetails = () => {
+  const dispatch = useDispatch();
+	 
+  const [loadingProject, setLoadingProject] = useState(true);
+  const [projectData, setProjectData] = useState(null);
+  const [isModalVisible, setIsModalVisible] = useState(false);
+  const [selectedUsers, setSelectedUsers] = useState([]);
+  const [userResults, setUserResults] = useState([]);
+  const [selectedFile, setSelectedFile] = useState(-1);
+  const { Search } = Input;
+
+  const { projectId } = useParams()
+  const history = useHistory()
+
+  useEffect(() => {
+    setLoadingProject(true)
+    api({sendToken: true})
+    .get("/post/get/" + projectId + "/1")
+    .then((response) => {
+      setProjectData(response.data[0])
+      setLoadingProject(false)
+      //console.log(response)
+    }).catch((error) => {
+      console.log(error)
+    })
+  }, [projectId]);
+
+  const displayCollabs = () => {
+    var u = projectData.user;
+    var user = (
+      <UserDiv key={0} onClick={() => redirectToProfile(projectData.userId)}>
+        <Col>
+          <Avatar size={64} src={u.profile_picture_url} />
+        </Col>
+        <Col style={{ paddingLeft: "15px" }}>
+          <H3 style={{ margin: "auto" }}>
+            {" "}
+            {u.name + " " + u.surname}
+          </H3>
+          <FadedDark> {"Project Owner"} </FadedDark>
+          <FadedText> {u.university} </FadedText>
+          <FadedText> {u.department} </FadedText>
+        </Col>
+      </UserDiv>
+    );
+
+    var collabs = projectData.project_collaborators.map((c, i) => {
+      if (c.user === null) return "";
+      
+      return (
+        <IndentedBlock key={i + 1}>
+          <UserDiv key={i + 1} onClick={() => redirectToProfile(c.user_id)}>
+            <Col>
+              <Avatar size={48} src={c.user.profile_picture_url} />
+            </Col>
+            <Col style={{ paddingLeft: "15px" }}>
+              <H3 style={{ margin: "auto" }}>
+                {" "}
+                {c.user.name + " " + c.user.surname}
+              </H3>
+              <FadedDark> {"Collaborator"} </FadedDark>
+              <FadedText> {c.user.university} </FadedText>
+              <FadedText> {c.user.department} </FadedText>
+            </Col>
+          </UserDiv>
+        </IndentedBlock>
+      );
+    });
+
+    return [user, ...collabs];
+  };
+
+  const statusMap = ["cancelled", "completed", "in progress", "team building", "hibernating"]
+  const statusColorMap = ["red", "green", "cyan", "purple", "volcano"]
+
+  const deadlineColor = (deadline_str) => {
+    var deadline = new Date(deadline_str);
+    var today = new Date();
+    if (today > deadline) {
+      return "red"
+    }
+    else if(today < deadline){
+      return "yellowgreen"
+    }
+    else{
+      return "orange"
+    }
+  }
+
+  const redirectToProfile = (profile_id) => {
+    history.push({ pathname: "/profile/" + profile_id })
+  }
+
+  const downloadFile = (filename) => {
+    api({sendToken: true})
+    .get("/file/get/" + projectId + "/" + filename)
+    .then((response) => {
+      var element = document.createElement('a');
+      element.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(response.data));
+      element.setAttribute('download', filename);
+
+      element.style.display = 'none';
+      document.body.appendChild(element);
+
+      element.click();
+    }).catch((error) => {
+      console.log(error)
+    })
+  }
+
+  const isUserCollaboratesOnThisProject = () => {
+    
+    var myId = parseInt(localStorage.getItem("userId"));
+
+    console.log("collabos", projectData.project_collaborators)
+
+    if(projectData.userId === myId){
+      return true
+    }
+
+    for (const c of projectData.project_collaborators){
+      if(c.user_id === myId){
+        return true
+      }
+    } 
+
+    return false
+  }
+  
+  const dueDateExists = () => {
+    return projectData.project_milestones.filter((m) => m.title === "Due Date").length > 0;
+  };
+  
+  const handleJoinRequest = () => {
+    const myId = localStorage.getItem("userId");
+
+    dispatch(sendJoinRequest(myId, projectData.userId, projectData.id));
+  };
+
+  const handleInviteRequest = () => {
+    const myId = localStorage.getItem("userId");
+
+    const selected_id_list = selectedUsers.map((u) => {
+      return u.id
+    })
+
+    dispatch(sendBatchInviteRequest(myId, selected_id_list, projectData.id));
+
+    setIsModalVisible(false);
+  };
+
+  const showModal = () => {
+    setIsModalVisible(true);
+  };
+
+  const inviteCollaborators = () => {
+    const myId = parseInt(localStorage.getItem("userId"));
+
+    const requestList = selectedUsers.map((u,i) => {
+      return [
+        myId,
+        u.id,
+        projectData.projectId,
+        0 // inviting to collaborate
+      ]
+    })
+
+    const body = {
+      requests: requestList
+    }
+
+    api({ sendToken: true })
+    .post("/collab/add_request", body)
+    .then((response) => {
+      //console.log(response)
+    })
+    .catch((error) => {
+      //console.log(error)
+    })
+
+    setIsModalVisible(false);
+  };
+
+  const handleCancel = () => {
+    setIsModalVisible(false);
+  };
+
+  const onSearch = (query) => {
+    api({ sendToken: true })
+    .get("/search", {
+      params: {
+        query: query,
+        type: 0
+      }
+    })
+    .then((response) => {
+      setUserResults(response.data.users)
+      console.log(response.data.users)
+    })
+    .catch((error) => {
+      //console.log(error)
+    })
+  }
+
+  return (  
+    
+    <Frame>
+      <UserModal 
+      title="Invite Collaborators" 
+      visible={isModalVisible} 
+      onOk={inviteCollaborators} 
+      onCancel={handleCancel}
+      okText="Invite"
+      cancelText="Cancel"
+      okButtonProps={{ backgroundColor: "red" }}
+      cancelButtonProps={{ disabled: true }}
+      bodyStyle= {{
+        maxHeight: "60vh", 
+        overflowY: "auto"
+      }}
+      footer={[
+        <Button key="cancel" type="text" onClick={handleCancel}>
+          Cancel
+        </Button>,
+        <Button key="ok" type="text" style={{color: theme.main.colors.first}} onClick={handleInviteRequest}>
+          Invite
+        </Button>,
+      ]}>
+        <Search
+        placeholder="search user name"
+        allowClear
+        onSearch={onSearch}/>
+        <br/>
+        <br/>
+        {selectedUsers.length > 0 ? "Selected Users" : null}
+        {selectedUsers.map((u,i) => {
+          return <>
+          <UserResult
+          img={u.profile_picture_url}
+          name={u.name + " " + u.surname}
+          department={u.department}
+          university={u.university}
+          selected={true}
+          profileLink={() => history.push("/profile/" + u.id)}
+          buttonClicked={() => setSelectedUsers(prev => {
+            return prev.filter((item) => item.id !== u.id);
+          })}
+          />
+          </>
+        })}
+        <br/>
+        Search Results
+        {userResults.map((u,i) => {
+          return Object.values(selectedUsers).includes(u) ? null : <>
+          <UserResult
+          img={u.profile_picture_url}
+          name={u.name + " " + u.surname}
+          department={u.department}
+          university={u.university}
+          selected={false}
+          buttonClicked={() => setSelectedUsers(prev => {
+            return [
+              ...prev,
+              u
+            ]
+          })}
+          />
+          </>
+        })}
+      </UserModal>
+
+      {
+      (loadingProject) ?  <Main
+        xs={{span: 20, offset: 1}}
+        sm={{span: 20, offset: 1}}
+        md={{span: 20, offset: 1}}
+        lg={{span: 12, offset: 5}}>
+          <Spin size="large" /> Content is Loading
+        </Main>:
+      (((projectData.privacy === 0) && !isUserCollaboratesOnThisProject())? // if it is private
+      <>
+        <Main
+          xs={{span: 20, offset: 1}}
+          sm={{span: 20, offset: 1}}
+          md={{span: 20, offset: 1}}
+          lg={{span: 12, offset: 5}}> 
+          <H1> {projectData.title} </H1>
+          This Project is Private
+        </Main>
+        <Side lg={{ span: 7, offset: 0 }} xl={{ span: 7, offset: 0 }}>
+          <div style={{ width: "80%", marginBottom: "20px" }}>
+            <PrimaryButton icon={<UsergroupAddOutlined />} onClick={handleJoinRequest}>
+              Send Join Request
+            </PrimaryButton>
+          </div>
+          <H4> Project Owner and Collaborators</H4>
+          {displayCollabs()}
+          <H4> Project Requirements </H4>
+	      	{projectData.requirements}
+        </Side>
+      </>
+      : // if it is not private
+      <>
+        <Main
+        xs={{span: 20, offset: 1}}
+        sm={{span: 20, offset: 1}}
+        md={{span: 20, offset: 1}}
+        lg={{span: 12, offset: 5}}> 
+        <H1> {projectData.title} </H1>
+        <DateSection>
+          {projectData.privacy === 0 ? <LockFilled/> : <UnlockFilled/>}
+          Project Due{" "}
+        {!(projectData.project_milestones === null || projectData.project_milestones === undefined) && projectData.project_milestones.length > 0 
+        ? moment(
+          projectData.project_milestones[projectData.project_milestones.length - 1].date
+          ).format("DD/MM/YYYY")
+        : "Unknown"}
+          <Tag 
+          color={statusColorMap[projectData.status]} 
+          style={{
+            marginLeft: "5px"
+          }}>
+            {statusMap[projectData.status]}
+          </Tag>
+        </DateSection>
+        <Tags>
+        {projectData.project_tags.map((t, i) => {
+          return (
+            <Tag key={i} style={{ color: "grey" }}>
+            {" "}
+            {t.tag}{" "}
+            </Tag>
+          );
+          })}
+          </Tags>
+          <Summary>
+            <H3>Summary</H3>
+            {projectData.summary}
+          </Summary>
+          {projectData.project_milestones.length > 0 ? (
+                  <Deadlines>
+                    <H3>Milestones</H3>
+                    {projectData.project_milestones.map((dl, i) => {
+                      return (
+                        <p key={i}>
+                          <ClockCircleTwoTone
+                            twoToneColor={deadlineColor(dl.date)}
+                            style={{ fontSize: "12px", marginRight: "8px" }}
+                          />
+                          {moment(dl.date).format("DD/MM/YYYY")} &nbsp;&nbsp;
+                          {dl.title}
+                          <br />
+                          {dl.description}
+                        </p>
+                      );
+                    })}
+                  </Deadlines>
+                ) : (
+                  ""
+                )}
+          <Files>
+            <H3>
+              Project Files
+              &nbsp;
+              { 
+                isUserCollaboratesOnThisProject() ?
+                <EditFilled 
+                  style={{cursor: "pointer"}}
+                  onClick={e => (history.push("/project/editfiles/" + projectId))}
+                />
+                :
+                ""
+              }
+            </H3>
+            
+            <FileContainer style={{}}>
+            {
+              projectData.project_files.length > 0 
+              ?
+              projectData.project_files.map((f, i) => {
+              return (
+                <FileDiv
+                  key={i}
+                  onClick={() => setSelectedFile(i)}
+                  download={f.file_name}
+                  style={{backgroundColor: selectedFile === i ? "#AAD2BA" : "transparent"}}
+                >
+                <FileOutlined style={{ fontSize: "28px" }} /> {f.file_name}
+                </FileDiv>
+              )})
+              : 
+              <div style={{ color: "grey", marginTop: "28px" }}>No Files To Display</div>
+            }
+            </FileContainer>
+            {
+            selectedFile === -1 || selectedFile === null 
+            ? ""
+            :
+            <Col>
+              <Row style={{marginTop: "16px"}}>
+                <Tag
+                  color="green"
+                  style={{ cursor: "pointer" }}
+                  onClick={(e) => (downloadFile(projectData.project_files[selectedFile].file_name))}
+                >
+                  Download File
+                </Tag>
+              </Row>
+            </Col>
+          }
+          </Files>
+          <div
+            style={{height: "50px"}}
+          />
+        </Main>
+        <Side lg={{ span: 7, offset: 0 }} xl={{ span: 7, offset: 0 }}>
+          {
+            isUserCollaboratesOnThisProject() ? (
+            <div style={{ width: "80%", marginBottom: "20px" }}>
+              <PrimaryButton
+              icon={<EditFilled />}
+              onClick={(e) => history.push("/project/edit/" + projectId)}
+              >
+              Edit Project
+              </PrimaryButton>
+              <br/><br/>
+              <PrimaryButton icon={<UsergroupAddOutlined />} onClick={() => showModal()}>
+              Invite Collaborators
+              </PrimaryButton>
+            </div>
+            ) : (
+            <div style={{ width: "80%", marginBottom: "20px" }}>
+              <PrimaryButton icon={<UsergroupAddOutlined />} onClick={handleJoinRequest}>
+              Send Join Request
+              </PrimaryButton>
+            </div>
+            )
+          }
+          <H4> Project Owner and Collaborators</H4>
+          {displayCollabs()}
+          <H4> Project Requirements </H4>
+          {projectData.requirements}
+        </Side>
+      </>)
+      }
+    </Frame>
+  );
+};
+
+export default EventDetails;

--- a/frontend/src/pages/EventDetails/index.jsx
+++ b/frontend/src/pages/EventDetails/index.jsx
@@ -11,13 +11,17 @@ import {
   ClockCircleTwoTone,
   EditFilled,
   UsergroupAddOutlined,
+  LinkOutlined,
   LockFilled,
+  PushpinOutlined,
+  PushpinTwoTone,
 } from "@ant-design/icons";
 import { sendJoinRequest, sendBatchInviteRequest } from "../../redux/collaboration/api";
 import Frame from "../../components/Frame";
 import PrimaryButton from "../../components/PrimaryButton";
 import {
   H1,
+  H2,
   H3,
   H4,
   Main,
@@ -38,11 +42,31 @@ import {
 import theme from "../../theme";
 import UserResult from "./components/UserResult";
 
+// src: https://forum.freecodecamp.org/t/newline-in-react-string-solved/68484
+function NewlineText(text) {
+  return text.split('\n').map(s => <>{s}<br/></>)  
+}
+
+
 const EventDetails = () => {
+
+  const eventData = {
+    eventId: 5,
+    userId: 3,
+    eventType: 'Rave Party',
+    tags: ['Ankara', 'Birds of Mind'],
+    isPublic: true,
+    eventTitle: 'MONGO B-Party',
+    eventBody: 'Come join us at Rave Istanbul to enjoy this unique and action-packed party that will have you on your feet all night long! Be prepared for unexpected surprise acts, packed events, and a wild adventure that will have you dancing and jumping until the end of the night!\n\nFriday, June 6th:\n10:00 PM: WELCOME\n10:30 PM: Rave Party\nMidnight: Foam Shower\n\nOrganized by Kusadasi Spring Festival',
+    eventLink: 'https://www.raveparty.com/',
+    location: 'Osmanbey / ISTANBUL',
+    date: '06/06/2021',
+    other: 'Strimg',
+  }
   const dispatch = useDispatch();
 	 
   const [loadingProject, setLoadingProject] = useState(true);
-  const [projectData, setProjectData] = useState(null);
+  //const [projectData, setProjectData] = useState(null);
   const [isModalVisible, setIsModalVisible] = useState(false);
   const [selectedUsers, setSelectedUsers] = useState([]);
   const [userResults, setUserResults] = useState([]);
@@ -52,12 +76,14 @@ const EventDetails = () => {
   const { projectId } = useParams()
   const history = useHistory()
 
+  var myId = parseInt(localStorage.getItem("userId"));
+
   useEffect(() => {
     setLoadingProject(true)
     api({sendToken: true})
     .get("/post/get/" + projectId + "/1")
     .then((response) => {
-      setProjectData(response.data[0])
+      //setProjectData(response.data[0])
       setLoadingProject(false)
       //console.log(response)
     }).catch((error) => {
@@ -65,53 +91,7 @@ const EventDetails = () => {
     })
   }, [projectId]);
 
-  const displayCollabs = () => {
-    var u = projectData.user;
-    var user = (
-      <UserDiv key={0} onClick={() => redirectToProfile(projectData.userId)}>
-        <Col>
-          <Avatar size={64} src={u.profile_picture_url} />
-        </Col>
-        <Col style={{ paddingLeft: "15px" }}>
-          <H3 style={{ margin: "auto" }}>
-            {" "}
-            {u.name + " " + u.surname}
-          </H3>
-          <FadedDark> {"Project Owner"} </FadedDark>
-          <FadedText> {u.university} </FadedText>
-          <FadedText> {u.department} </FadedText>
-        </Col>
-      </UserDiv>
-    );
 
-    var collabs = projectData.project_collaborators.map((c, i) => {
-      if (c.user === null) return "";
-      
-      return (
-        <IndentedBlock key={i + 1}>
-          <UserDiv key={i + 1} onClick={() => redirectToProfile(c.user_id)}>
-            <Col>
-              <Avatar size={48} src={c.user.profile_picture_url} />
-            </Col>
-            <Col style={{ paddingLeft: "15px" }}>
-              <H3 style={{ margin: "auto" }}>
-                {" "}
-                {c.user.name + " " + c.user.surname}
-              </H3>
-              <FadedDark> {"Collaborator"} </FadedDark>
-              <FadedText> {c.user.university} </FadedText>
-              <FadedText> {c.user.department} </FadedText>
-            </Col>
-          </UserDiv>
-        </IndentedBlock>
-      );
-    });
-
-    return [user, ...collabs];
-  };
-
-  const statusMap = ["cancelled", "completed", "in progress", "team building", "hibernating"]
-  const statusColorMap = ["red", "green", "cyan", "purple", "volcano"]
 
   const deadlineColor = (deadline_str) => {
     var deadline = new Date(deadline_str);
@@ -127,361 +107,97 @@ const EventDetails = () => {
     }
   }
 
-  const redirectToProfile = (profile_id) => {
-    history.push({ pathname: "/profile/" + profile_id })
-  }
-
-  const downloadFile = (filename) => {
-    api({sendToken: true})
-    .get("/file/get/" + projectId + "/" + filename)
-    .then((response) => {
-      var element = document.createElement('a');
-      element.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(response.data));
-      element.setAttribute('download', filename);
-
-      element.style.display = 'none';
-      document.body.appendChild(element);
-
-      element.click();
-    }).catch((error) => {
-      console.log(error)
-    })
-  }
-
-  const isUserCollaboratesOnThisProject = () => {
-    
-    var myId = parseInt(localStorage.getItem("userId"));
-
-    console.log("collabos", projectData.project_collaborators)
-
-    if(projectData.userId === myId){
-      return true
-    }
-
-    for (const c of projectData.project_collaborators){
-      if(c.user_id === myId){
-        return true
-      }
-    } 
-
-    return false
-  }
-  
-  const dueDateExists = () => {
-    return projectData.project_milestones.filter((m) => m.title === "Due Date").length > 0;
-  };
-  
-  const handleJoinRequest = () => {
-    const myId = localStorage.getItem("userId");
-
-    dispatch(sendJoinRequest(myId, projectData.userId, projectData.id));
-  };
-
-  const handleInviteRequest = () => {
-    const myId = localStorage.getItem("userId");
-
-    const selected_id_list = selectedUsers.map((u) => {
-      return u.id
-    })
-
-    dispatch(sendBatchInviteRequest(myId, selected_id_list, projectData.id));
-
-    setIsModalVisible(false);
-  };
-
-  const showModal = () => {
-    setIsModalVisible(true);
-  };
-
-  const inviteCollaborators = () => {
-    const myId = parseInt(localStorage.getItem("userId"));
-
-    const requestList = selectedUsers.map((u,i) => {
-      return [
-        myId,
-        u.id,
-        projectData.projectId,
-        0 // inviting to collaborate
-      ]
-    })
-
-    const body = {
-      requests: requestList
-    }
-
-    api({ sendToken: true })
-    .post("/collab/add_request", body)
-    .then((response) => {
-      //console.log(response)
-    })
-    .catch((error) => {
-      //console.log(error)
-    })
-
-    setIsModalVisible(false);
-  };
-
-  const handleCancel = () => {
-    setIsModalVisible(false);
-  };
-
-  const onSearch = (query) => {
-    api({ sendToken: true })
-    .get("/search", {
-      params: {
-        query: query,
-        type: 0
-      }
-    })
-    .then((response) => {
-      setUserResults(response.data.users)
-      console.log(response.data.users)
-    })
-    .catch((error) => {
-      //console.log(error)
-    })
-  }
-
   return (  
     
     <Frame>
-      <UserModal 
-      title="Invite Collaborators" 
-      visible={isModalVisible} 
-      onOk={inviteCollaborators} 
-      onCancel={handleCancel}
-      okText="Invite"
-      cancelText="Cancel"
-      okButtonProps={{ backgroundColor: "red" }}
-      cancelButtonProps={{ disabled: true }}
-      bodyStyle= {{
-        maxHeight: "60vh", 
-        overflowY: "auto"
-      }}
-      footer={[
-        <Button key="cancel" type="text" onClick={handleCancel}>
-          Cancel
-        </Button>,
-        <Button key="ok" type="text" style={{color: theme.main.colors.first}} onClick={handleInviteRequest}>
-          Invite
-        </Button>,
-      ]}>
-        <Search
-        placeholder="search user name"
-        allowClear
-        onSearch={onSearch}/>
-        <br/>
-        <br/>
-        {selectedUsers.length > 0 ? "Selected Users" : null}
-        {selectedUsers.map((u,i) => {
-          return <>
-          <UserResult
-          img={u.profile_picture_url}
-          name={u.name + " " + u.surname}
-          department={u.department}
-          university={u.university}
-          selected={true}
-          profileLink={() => history.push("/profile/" + u.id)}
-          buttonClicked={() => setSelectedUsers(prev => {
-            return prev.filter((item) => item.id !== u.id);
-          })}
-          />
-          </>
-        })}
-        <br/>
-        Search Results
-        {userResults.map((u,i) => {
-          return Object.values(selectedUsers).includes(u) ? null : <>
-          <UserResult
-          img={u.profile_picture_url}
-          name={u.name + " " + u.surname}
-          department={u.department}
-          university={u.university}
-          selected={false}
-          buttonClicked={() => setSelectedUsers(prev => {
-            return [
-              ...prev,
-              u
-            ]
-          })}
-          />
-          </>
-        })}
-      </UserModal>
-
       {
-      (loadingProject) ?  <Main
+      (loadingProject) ?  
+        <Main
         xs={{span: 20, offset: 1}}
         sm={{span: 20, offset: 1}}
         md={{span: 20, offset: 1}}
         lg={{span: 12, offset: 5}}>
           <Spin size="large" /> Content is Loading
-        </Main>:
-      (((projectData.privacy === 0) && !isUserCollaboratesOnThisProject())? // if it is private
-      <>
-        <Main
-          xs={{span: 20, offset: 1}}
-          sm={{span: 20, offset: 1}}
-          md={{span: 20, offset: 1}}
-          lg={{span: 12, offset: 5}}> 
-          <H1> {projectData.title} </H1>
-          This Project is Private
         </Main>
-        <Side lg={{ span: 7, offset: 0 }} xl={{ span: 7, offset: 0 }}>
-          <div style={{ width: "80%", marginBottom: "20px" }}>
-            <PrimaryButton icon={<UsergroupAddOutlined />} onClick={handleJoinRequest}>
-              Send Join Request
-            </PrimaryButton>
-          </div>
-          <H4> Project Owner and Collaborators</H4>
-          {displayCollabs()}
-          <H4> Project Requirements </H4>
-	      	{projectData.requirements}
-        </Side>
-      </>
-      : // if it is not private
-      <>
+        :
+        <>
         <Main
         xs={{span: 20, offset: 1}}
         sm={{span: 20, offset: 1}}
         md={{span: 20, offset: 1}}
         lg={{span: 12, offset: 5}}> 
-        <H1> {projectData.title} </H1>
+        <H1> {eventData.eventTitle} </H1>
+        <H2> {eventData.eventType} </H2>
         <DateSection>
-          {projectData.privacy === 0 ? <LockFilled/> : <UnlockFilled/>}
-          Project Due{" "}
-        {!(projectData.project_milestones === null || projectData.project_milestones === undefined) && projectData.project_milestones.length > 0 
-        ? moment(
-          projectData.project_milestones[projectData.project_milestones.length - 1].date
-          ).format("DD/MM/YYYY")
-        : "Unknown"}
-          <Tag 
-          color={statusColorMap[projectData.status]} 
-          style={{
-            marginLeft: "5px"
-          }}>
-            {statusMap[projectData.status]}
-          </Tag>
+          {!(eventData.date == undefined | eventData.date == null) ? (
+              <span>
+                <ClockCircleTwoTone
+                  twoToneColor={deadlineColor(eventData.date)}
+                  style={{ fontSize: "12px", marginRight: "8px" }}
+                />
+                {moment(eventData.date).format("DD/MM/YYYY")} &nbsp;
+              </span>
+            ) : (
+              <></>
+          )}
+          <br/>
+          {!(eventData.location == undefined | eventData.location == null) ? (
+            <span>
+              <PushpinTwoTone
+                twoToneColor={'firebrick'}
+                style={{ fontSize: "12px", marginRight: "8px" }}
+              />
+              {eventData.location} &nbsp;
+            </span>
+          ) : (
+            <></>
+          )}
         </DateSection>
         <Tags>
-        {projectData.project_tags.map((t, i) => {
+        {eventData.tags.map((t, i) => {
           return (
             <Tag key={i} style={{ color: "grey" }}>
             {" "}
-            {t.tag}{" "}
+            {t}{" "}
             </Tag>
           );
           })}
           </Tags>
           <Summary>
-            <H3>Summary</H3>
-            {projectData.summary}
+            <H2>Description</H2>
+            {NewlineText(eventData.eventBody)}
           </Summary>
-          {projectData.project_milestones.length > 0 ? (
-                  <Deadlines>
-                    <H3>Milestones</H3>
-                    {projectData.project_milestones.map((dl, i) => {
-                      return (
-                        <p key={i}>
-                          <ClockCircleTwoTone
-                            twoToneColor={deadlineColor(dl.date)}
-                            style={{ fontSize: "12px", marginRight: "8px" }}
-                          />
-                          {moment(dl.date).format("DD/MM/YYYY")} &nbsp;&nbsp;
-                          {dl.title}
-                          <br />
-                          {dl.description}
-                        </p>
-                      );
-                    })}
-                  </Deadlines>
-                ) : (
-                  ""
-                )}
-          <Files>
-            <H3>
-              Project Files
-              &nbsp;
-              { 
-                isUserCollaboratesOnThisProject() ?
-                <EditFilled 
-                  style={{cursor: "pointer"}}
-                  onClick={e => (history.push("/project/editfiles/" + projectId))}
-                />
-                :
-                ""
-              }
-            </H3>
-            
-            <FileContainer style={{}}>
-            {
-              projectData.project_files.length > 0 
-              ?
-              projectData.project_files.map((f, i) => {
-              return (
-                <FileDiv
-                  key={i}
-                  onClick={() => setSelectedFile(i)}
-                  download={f.file_name}
-                  style={{backgroundColor: selectedFile === i ? "#AAD2BA" : "transparent"}}
-                >
-                <FileOutlined style={{ fontSize: "28px" }} /> {f.file_name}
-                </FileDiv>
-              )})
-              : 
-              <div style={{ color: "grey", marginTop: "28px" }}>No Files To Display</div>
-            }
-            </FileContainer>
-            {
-            selectedFile === -1 || selectedFile === null 
-            ? ""
-            :
-            <Col>
-              <Row style={{marginTop: "16px"}}>
-                <Tag
-                  color="green"
-                  style={{ cursor: "pointer" }}
-                  onClick={(e) => (downloadFile(projectData.project_files[selectedFile].file_name))}
-                >
-                  Download File
-                </Tag>
-              </Row>
-            </Col>
-          }
-          </Files>
           <div
             style={{height: "50px"}}
           />
         </Main>
         <Side lg={{ span: 7, offset: 0 }} xl={{ span: 7, offset: 0 }}>
           {
-            isUserCollaboratesOnThisProject() ? (
+            myId == eventData.userId ? (
             <div style={{ width: "80%", marginBottom: "20px" }}>
               <PrimaryButton
               icon={<EditFilled />}
-              onClick={(e) => history.push("/project/edit/" + projectId)}
+              onClick={(e) => history.push("/event/edit/" + projectId)}
               >
-              Edit Project
-              </PrimaryButton>
-              <br/><br/>
-              <PrimaryButton icon={<UsergroupAddOutlined />} onClick={() => showModal()}>
-              Invite Collaborators
+              Edit Event
               </PrimaryButton>
             </div>
             ) : (
             <div style={{ width: "80%", marginBottom: "20px" }}>
-              <PrimaryButton icon={<UsergroupAddOutlined />} onClick={handleJoinRequest}>
-              Send Join Request
+              <PrimaryButton icon={<UsergroupAddOutlined />} onClick={e=>(null /**TODO */)}>
+              Save Event
               </PrimaryButton>
             </div>
             )
           }
-          <H4> Project Owner and Collaborators</H4>
-          {displayCollabs()}
-          <H4> Project Requirements </H4>
-          {projectData.requirements}
+          <a 
+            href={eventData.eventLink} title={eventData.eventLink}
+            target='_blank'
+          >
+            <H4> Visit Webpage <LinkOutlined /></H4>
+          </a>
         </Side>
-      </>)
+      </>
       }
     </Frame>
   );

--- a/frontend/src/pages/EventDetails/style.js
+++ b/frontend/src/pages/EventDetails/style.js
@@ -1,0 +1,197 @@
+import styled from "styled-components";
+import theme from "../../theme";
+import { Col, Modal } from "antd";
+import { EditOutlined } from '@ant-design/icons';
+
+export const Main = styled(Col)` 
+  padding: 20px;
+
+  @media only screen and (max-width: 768px) {
+    padding-top: 30px;
+  }
+
+  @media only screen and (min-width: 768px) {
+    padding-top: 50px;
+  }
+`; 
+
+export const Side = styled(Col)`
+  padding: 0 30px;
+
+  @media only screen and (max-width: 768px) {
+    margin-top: 42px;
+  }
+
+  @media only screen and (min-width: 768px) {
+    border-left: solid 2px black; 
+    margin-top: 70px;
+    border-image:
+    linear-gradient(
+      to bottom, 
+      rgba(255,255,255,1),
+      rgba(107,143,113,0.5), 
+      rgba(255,255,255,1)
+    ) 1 85%;
+  }
+`;
+
+export const EditButton = styled(EditOutlined)` 
+
+  cursor: pointer;
+  color: ${theme.main.colors.third};
+
+  :hover {
+    color: ${theme.main.colors.first};
+  }
+`; 
+
+export const IndentedBlock = styled.div` 
+  margin-left: 16px;
+`; 
+
+
+export const DateSection = styled.p` 
+  color: grey;
+`; 
+
+export const Tags = styled.div` 
+  margin-top: 30px;
+`; 
+
+export const EditWrapper = styled.div` 
+  margin-top: 16px;
+`; 
+
+export const Summary = styled.div` 
+  margin-top: 16px;
+`; 
+
+export const Deadlines = styled.div` 
+  margin-top: 30px;
+`; 
+
+export const Files = styled.div` 
+  margin-top: 30px;
+`; 
+
+export const FileContainer = styled.div` 
+  border: solid 2px #E4E4E4;
+  border-radius: 5px;
+  min-height: 80px;
+
+  text-align:center;
+
+  @media only screen and (max-width: 768px) {
+    width: 100%;
+  }
+  
+  @media only screen and (min-width: 768px) {
+    width: 80%;
+  }
+`; 
+
+export const UserDiv = styled(Col)` 
+  padding: 5px 0px;
+  display: flex;
+  flex-direction: row;
+  justify-content: start;
+  align-items: start;
+  cursor: pointer;
+`; 
+
+export const FileDiv = styled.a`
+  display: flex;
+  flex-direction: row; 
+  align-items: center;
+  fontsize: 16px;
+  padding: 5px 10px;
+  cursor: pointer;
+  color: black;
+
+  &:hover{
+    background-color: #efefef;
+  }
+`; 
+
+export const H1 = styled.h1` 
+  color: ${theme.main.colors.first};
+  margin-bottom: 0;
+
+  @media only screen and (max-width: 768px) {
+    font-size: 25px;
+  }
+  
+  @media only screen and (min-width: 768px) {
+    font-size: 36px;
+  }
+`;
+
+export const H2 = styled.h2`  
+  @media only screen and (max-width: 768px) {
+    font-size: 18px;
+  }
+  
+  @media only screen and (min-width: 768px) {
+    font-size: 24px;
+  }
+`;
+
+export const H3 = styled.h3` 
+  text-align: left;
+
+  @media only screen and (max-width: 768px) {
+    font-size: 14px;
+  }
+  
+  @media only screen and (min-width: 768px) {
+    font-size: 16px;
+  }
+`;
+
+export const H4 = styled.h4` 
+  text-align: left;
+
+  @media only screen and (max-width: 768px) {
+    font-size: 12px;
+  }
+  
+  @media only screen and (min-width: 768px) {
+    font-size: 14px;
+  }
+`;
+
+export const FadedText = styled.p` 
+  margin: auto;
+  padding: auto;
+  text-align: left;
+  color: grey;
+
+  @media only screen and (max-width: 768px) {
+    font-size: 10px;
+  }
+  
+  @media only screen and (min-width: 768px) {
+    font-size: 12px;
+  }
+`;
+
+export const UserModal = styled(Modal)` 
+.ant-modal-content {
+  border-radius: 15px;
+  padding: 0 18px;
+}`
+
+export const FadedDark = styled.p` 
+  margin: auto;
+  padding: auto;
+  text-align: left;
+  color: ${theme.main.colors.third};
+
+  @media only screen and (max-width: 768px) {
+    font-size: 10px;
+  }
+  
+  @media only screen and (min-width: 768px) {
+    font-size: 12px;
+  }
+`;

--- a/frontend/src/routes.jsx
+++ b/frontend/src/routes.jsx
@@ -80,7 +80,7 @@ export default function App() {
         <Route path="/project">
           <CreateProject />
         </Route>
-        <Route path="/event/details/:projectId">
+        <Route path="/event/details/:eventId">
           <EventDetails />
         </Route>
         <Route path="/profile/:id">

--- a/frontend/src/routes.jsx
+++ b/frontend/src/routes.jsx
@@ -10,6 +10,7 @@ import Search from "./pages/Search";
 import CreateProject from "./pages/CreateProject";
 import EditProject from "./pages/EditProject";
 import ProjectDetails from "./pages/ProjectDetails";
+import EventDetails from "./pages/EventDetails";
 import FileEditor from "./pages/FileEditor";
 import Profile from "./pages/Profile";
 import ListFollowers from "./pages/ListFollow";
@@ -78,6 +79,9 @@ export default function App() {
         </Route>
         <Route path="/project">
           <CreateProject />
+        </Route>
+        <Route path="/event/details/:projectId">
+          <EventDetails />
         </Route>
         <Route path="/profile/:id">
           <Profile />


### PR DESCRIPTION
After #387 turned out to be pointing at a broken head, I merged frontend into frontend-event-details to re-merge frontend-event-details.

See contents of #387 here below:

> I have implemented the Event Details page.
> 
> It displays the following fields of an event object:
> 
> * Title
> * Date
> * Type
> * Location
> * Description
> * Link (External URL)
> * Other (Additional Info)
> 
> It also has a functional save/unsave button (Fav).
> 
> * I created the route for it on `/event/details/:id`
> 
> Example screenshot:
> ![Screenshot from 2021-01-23 21-05-12](https://user-images.githubusercontent.com/44120900/105610096-bd896680-5dbe-11eb-81bf-b0629e74178f.png)

