### PR TITLE
Frontend Saved (Favourited) Events Page

### DIFF
--- a/frontend/src/components/ProfileSider/index.jsx
+++ b/frontend/src/components/ProfileSider/index.jsx
@@ -10,6 +10,7 @@ import {
   ContainerOutlined,
   CalendarOutlined,
   UnorderedListOutlined,
+  AppstoreAddOutlined,
 } from "@ant-design/icons";
 import { Layout, NameText, Img } from "./style";
 import GoogleScholarModal from "../GoogleScholarModal";
@@ -111,6 +112,13 @@ const ProfileSider = () => {
                 icon={<UnorderedListOutlined />}
               >
                 Events
+              </Menu.Item>
+              <Menu.Item
+                key="6"
+                onClick={() => history.push("/event/saved")}
+                icon={<AppstoreAddOutlined />}
+              >
+                Saved Events
               </Menu.Item>
             </Menu>
           </div>

--- a/frontend/src/pages/SavedEvents/index.jsx
+++ b/frontend/src/pages/SavedEvents/index.jsx
@@ -1,0 +1,172 @@
+import React, { useState, useEffect } from "react";
+
+import { Col, Spin } from "antd";
+import { List, Avatar, Space } from "antd";
+import {
+  CalendarTwoTone,
+  TagTwoTone,
+  EnvironmentTwoTone,
+} from "@ant-design/icons";
+import Frame from "../../components/Frame";
+import PersonRecommendationCard from "../../components/PersonRecommendationCard";
+import { Main, H2, H3, StHref } from "./style";
+
+import api from "../../axios";
+
+const SavedEvents = () => {
+  const [loading, setLoading] = useState(true);
+  const [feed, setFeed] = useState(null);
+  const [userRecommendationsLoading, setUserRecommendationsLoading] = useState(
+    true
+  );
+  const [userRecommendations, setUserRecommendations] = useState([]);
+
+  useEffect(() => {
+    const myId = localStorage.getItem("userId")
+
+    setLoading(true);
+    api({ sendToken: true })
+      .get("/event/favorites?userId=" + myId)
+      .then((response) => {
+        setFeed(response.data);
+        setLoading(false);
+        console.log(response.data);
+      })
+      .catch((error) => {
+        console.log(error);
+      });
+  }, []);
+
+  useEffect(() => {
+    setUserRecommendationsLoading(true);
+    api({ sendToken: true })
+      .get("/home/users")
+      .then((response) => {
+        console.log("resp", response);
+        setUserRecommendations(
+          [
+            ...response.data.sameDepartment,
+            ...response.data.sameUniversity,
+            ...response.data.similarInterests,
+          ].sort(() => 0.5 - Math.random())
+        );
+        setUserRecommendationsLoading(false);
+      })
+      .catch((error) => {
+        console.log(error);
+        setUserRecommendationsLoading(false);
+      });
+  }, []);
+
+  const IconText = ({ icon, text }) => (
+    <Space>
+      {React.createElement(icon)}
+      {text}
+    </Space>
+  );
+
+  return (
+    <Frame>
+      <Main
+        xs={{ span: 22, offset: 1 }}
+        sm={{ span: 22, offset: 1 }}
+        md={{ span: 22, offset: 1 }}
+        lg={{ span: 15, offset: 4 }}
+        style={{ marginTop: "32px" }}
+      >
+        {loading ? (
+          <H2>
+            Loading... <Spin />
+          </H2>
+        ) : (
+          <>
+            <H2>Saved Events</H2>
+            <List
+              itemLayout="vertical"
+              size="large"
+              pagination={{
+                onChange: (page) => {
+                  console.log(page);
+                },
+                pageSize: 4,
+              }}
+              dataSource={feed.result}
+              renderItem={(item) => (
+                <List.Item
+                  key={item.id}
+                  actions={[
+                    <IconText
+                      icon={() => <EnvironmentTwoTone twoToneColor="#6B8F71" />}
+                      text={item.location}
+                      key="list-vertical-star-o"
+                    />,
+                    <IconText
+                      icon={() => <CalendarTwoTone twoToneColor="#548d5d" />}
+                      text={item.date.substring(0, 10)}
+                      key="list-vertical-message"
+                    />,
+                    <IconText
+                      icon={() => <TagTwoTone twoToneColor="#548d5d" />}
+                      text={item.type}
+                      key="list-vertical-message"
+                    />,
+                  ]}
+                >
+                  <List.Item.Meta
+                    title={
+                      <StHref href={"/event/details/" + item.id}>
+                        {item.title}
+                      </StHref>
+                    }
+                    description={
+                      item.body.length < 150
+                        ? item.body.concat("...")
+                        : item.body.substring(0, 150).concat("...")
+                    }
+                  />
+                </List.Item>
+              )}
+            />
+          </>
+        )}
+      </Main>
+      <Col
+        style={{ position: "fixed", right: "20px", minWidth: "280px" }}
+        align="center"
+        span={0}
+        lg={{ span: 5, offset: 0 }}
+        xl={{ span: 4, offset: 1 }}
+      >
+        <H3>Recommended users</H3>
+        {userRecommendationsLoading ? (
+          <Spin />
+        ) : userRecommendations.length === 1 ? (
+          "No recommendations yet."
+        ) : (
+          userRecommendations
+            .filter((u) => u.id !== parseInt(localStorage.getItem("userId")))
+            .slice(0, 4)
+            .map((u, i) => {
+              return (
+                <PersonRecommendationCard
+                  id={u.id}
+                  key={i}
+                  name={u.name + " " + u.surname}
+                  university={u.university}
+                  department={u.department}
+                  imgUrl={u.profile_picture_url}
+                  onFollowed={() =>
+                    setUserRecommendations((prev) =>
+                      prev.filter((x) => x.id !== u.id)
+                    )
+                  }
+                />
+              );
+            })
+        )}
+      </Col>
+    </Frame>
+  );
+};
+
+export default SavedEvents;

--- a/frontend/src/pages/SavedEvents/style.js
+++ b/frontend/src/pages/SavedEvents/style.js
@@ -1,0 +1,78 @@
+import styled from "styled-components";
+import { Layout, Col } from "antd";
+
+export const Content = styled(Layout)`
+  height: 100vh;
+  background: white;
+`;
+
+export const Main = styled(Col)`
+  margin-top: 0px;
+
+  @media only screen and (min-width: 500px) {
+    padding: 0 50px;
+  }
+  @media only screen and (min-width: 600px) {
+    padding: 0 100px;
+  }
+  @media only screen and (min-width: 1200px) {
+    padding: 0 150px;
+  }
+`;
+
+export const StHref = styled.a`
+  color: #000000d9;
+  &:hover {
+    color: #548d5d;
+  }
+`;
+
+export const H1 = styled.h1`
+  color: #4e4e4e;
+  margin-bottom: 0;
+
+  @media only screen and (max-width: 768px) {
+    font-size: 24px;
+    margin-top: 24px;
+  }
+
+  @media only screen and (min-width: 768px) {
+    font-size: 32px;
+    margin-top: 32px;
+  }
+`;
+
+export const H2 = styled.h2`
+  @media only screen and (max-width: 768px) {
+    font-size: 18px;
+    margin: 18px auto;
+  }
+
+  @media only screen and (min-width: 768px) {
+    font-size: 24px;
+    margin: 24px auto;
+  }
+`;
+
+export const H3 = styled.h3`
+  text-align: left;
+  margin-top: 32px;
+
+  @media only screen and (max-width: 768px) {
+    font-size: 12px;
+    margin: 8px;
+  }
+
+  @media only screen and (min-width: 768px) {
+    font-size: 14px;
+    margin-left: 10px;
+  }
+`;
+
+export const FilterButton = styled.div`
+  height: 70px;
+  width: 70%;
+  padding: 5px 0;
+  border-radius: 10px;
+  background-color: beige;
+`;

--- a/frontend/src/routes.jsx
+++ b/frontend/src/routes.jsx
@@ -21,6 +21,7 @@ import Spinner from "./components/Spinner";
 import { Row, Col } from "antd";
 import CreateEvent from "./pages/CreateEvent";
 import EditEvent from "./pages/EditEvent";
+import SavedEvents from "./pages/SavedEvents";
 
 export default function App() {
   const [loading, setLoading] = useState(false);
@@ -79,6 +80,9 @@ export default function App() {
         </Route>
         <Route path="/events">
           <Events />
+        </Route>
+        <Route path="/event/saved">
+          <SavedEvents />
         </Route>
         <Route path="/search">
           <Search />


### PR DESCRIPTION
I have tweaked the events page implementation created by @dogruomerfaruk to create saved events page.

Work Done:
- events page is copied to be used as a base code.
- a title is added to state the purpose of the page.
- corresponding backend connections are made.
- a button is added to the profile sider in order to navigate this page.
- `event/saved` route is added to the routes.

screen shot:
![ex10](https://user-images.githubusercontent.com/42381853/105763900-578c1300-5f67-11eb-82d5-da4250ac10a7.PNG)

